### PR TITLE
Support for php ^7.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.2
   - 7.3
   - 7.4
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.2",
         "illuminate/support": "5.8.*|^6.0|^7.0",
         "symfony/stopwatch": "^4.0|^5.0"
     },


### PR DESCRIPTION
PHP 7.2 Still has security support. We have a lot of servers with 7.2 where we could use this package. 