### PR TITLE
Enable Flag from ENV Var

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -11,5 +11,5 @@ return [
     |
     */
 
-    'enabled' => true,
+    'enabled' => env('ENABLE_SERVER_TIMING', 'true') === 'true' ?? false,
 ];


### PR DESCRIPTION
This update allows for control of it's enable state.
I think this should be something included out of the box, I know its a simple change but its something that I think it's helpful as lots of things are controlled via ENV vars in the end.

I have it reading the ENV Value and checking if its string(true), if so then true otherwise false.
If no value is passed in then it defaults to true anyway so its the same result as if this was not added in.