### PR TITLE
Added an `addMessage` utility method, with a test and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ ServerTiming::setDuration('Running expensive task', function() {
 
 ## Adding textual information
 
-You can also use the Server-Timing middleware to only set textual information without providing a duration.
+You can also use the Server-Timing middleware to only set textual information:
+
+```php
+ServerTiming::addMessage('User: '.$user->id);
+```
 
 ## Publishing configuration file
 
@@ -67,10 +71,6 @@ The configuration file could be published using:
 `php artisan vendor:publish --tag=server-timing-config`
 
 You can disable the middleware changing the `timing.enabled` configuration to false.
-
-```php
-ServerTiming::addMetric('User: '.$user->id);
-```
 
 ### Testing
 

--- a/src/ServerTiming.php
+++ b/src/ServerTiming.php
@@ -90,6 +90,11 @@ class ServerTiming
         return $this->finishedEvents[$key] ?? null;
     }
 
+    public function addMessage(string $key)
+    {
+        $this->setDuration($key, null);
+    }
+
     public function events(): array
     {
         return $this->finishedEvents;

--- a/tests/ServerTimingTest.php
+++ b/tests/ServerTimingTest.php
@@ -82,6 +82,19 @@ class ServerTimingTest extends TestCase
     }
 
     /** @test */
+    public function it_can_add_messages()
+    {
+        $timing = new ServerTiming(new Stopwatch());
+        $timing->addMessage('Custom Message');
+
+        $events = $timing->events();
+
+        $this->assertCount(1, $events);
+        $this->assertTrue(array_key_exists('Custom Message', $events));
+        $this->assertNull($events['Custom Message']);
+    }
+
+    /** @test */
     public function it_can_stop_started_events()
     {
         $timing = new ServerTiming(new Stopwatch());


### PR DESCRIPTION
I went a bit deep trying to find out how to add a message (ie an entry without a duration) to the server timing output - as it turns out, there is an example in the docs but it has somehow been pushed a section down into the 'Publishing configuration file' setting.

By that point, I'd forked the repo and created an `addMessage` utility.