### PR TITLE
Fix getRequestStartTime for Octane workers

### DIFF
--- a/src/Middleware/ServerTimingMiddleware.php
+++ b/src/Middleware/ServerTimingMiddleware.php
@@ -53,10 +53,11 @@ class ServerTimingMiddleware
 
     protected function getRequestStartTime()
     {
-        if (defined('LARAVEL_START')) {
+        if (!request()->server('LARAVEL_OCTANE') && defined('LARAVEL_START')) {
             return LARAVEL_START;
         }
-        return $_SERVER["REQUEST_TIME_FLOAT"] ?? microtime(true);
+
+        return request()->server('REQUEST_TIME_FLOAT') ?? microtime(true);
     }
 
     protected function generateHeaders(): string


### PR DESCRIPTION
Fix defining `$this->start` via `getRequestStartTime()` for Laravel Octane workers
https://github.com/beyondcode/laravel-server-timing/issues/37

## Problem

Under Laravel Octane (Swoole/RoadRunner/FrankenPHP), worker processes are persistent and handle multiple requests during their lifetime. The previous implementation relied on `$_SERVER['REQUEST_TIME_FLOAT']` and the `LARAVEL_START` constant, both of which are set once at worker initialization and never updated between requests.

This caused `$this->start` to always reflect the start time of the **first request** handled by the worker, making all subsequent server timing measurements incorrect.

## Solution

Use `request()->server('REQUEST_TIME_FLOAT')` instead, which reads from the current request context that Octane properly resets on each request.

The `LARAVEL_START` constant is still used as a fallback for non-Octane environments where `$_SERVER` and constants behave as expected.

## Changes

- `getRequestStartTime()` now checks for `LARAVEL_OCTANE` in the request context to determine the runtime environment
- Replaced `$_SERVER` superglobal with `request()->server()` for Octane compatibility

<img width="2552" height="1246" alt="image" src="https://github.com/user-attachments/assets/2acbfef0-f530-41f1-9af4-3db51a08db9c" />
